### PR TITLE
bug fix

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -69,13 +69,6 @@ class PianobarSkill(MycroftSkill):
         self.settings.set_changed_callback(self.on_websettings_changed)
         self.on_websettings_changed()
 
-    def get_intro_message(self):
-        # This will be spoken on first installation
-        if not self._is_setup:
-            return self.translate("please.register.pandora")
-        else:
-            return None
-
     ######################################################################
     # 'Auto ducking' - pause playback when Mycroft wakes
 
@@ -135,10 +128,10 @@ class PianobarSkill(MycroftSkill):
             password = self.settings.get("password", "")
             try:
                 if email and password:
-                    self._is_setup = True
-                    self._register_all_intents()
                     self._configure_pianobar()
                     self._init_pianobar()
+                    self._register_all_intents()
+                    self._is_setup = True
             except Exception as e:
                 LOG.error(e)
 

--- a/__init__.py
+++ b/__init__.py
@@ -64,7 +64,6 @@ class PianobarSkill(MycroftSkill):
 
     def initialize(self):
         self._load_vocab_files()
-        self._init_pianobar()
 
         # Check and then monitor for credential changes
         self.settings.set_changed_callback(self.on_websettings_changed)
@@ -139,6 +138,7 @@ class PianobarSkill(MycroftSkill):
                     self._is_setup = True
                     self._register_all_intents()
                     self._configure_pianobar()
+                    self._init_pianobar()
             except Exception as e:
                 LOG.error(e)
 


### PR DESCRIPTION
moved the pianobar init to web settings changed. When pandora loaded and the credentials are not inputted, pianobar still get's init. during the init process pianobar will fail with the wrong credentials.
This is a fix that will init pianobar only if there are credentials.