### PR TITLE
Make sure the requirements.sh finishes with OK status

### DIFF
--- a/requirements.sh
+++ b/requirements.sh
@@ -11,3 +11,5 @@ found_exe() {
 if found_exe pkcon; then
     pkcon install pianobar -y
 fi
+
+exit 0


### PR DESCRIPTION
If the pianobar package is at the latest version pkcon returns error (since the package can't be installed), msm will not install requirements.txt this hinders the skill from being installed with the new version of msm.

(Side note, is the licensing of this Ok? Fuzzywuzzy is GPL afaik)