### PR TITLE
Volume, rating, track info, fixed auto ducking

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -124,6 +124,7 @@ class PianobarSkill(MycroftSkill):
         self.add_event('mycroft.audio.service.pause', self.handle_pause)
         self.add_event('mycroft.audio.service.resume', self.handle_resume_song)
         self.add_event('mycroft.audio.service.next', self.handle_next_song)
+        self.add_event('mycroft.audio.service.track_info', self.handle_track_info)
 
     def on_websettings_changed(self):
         if not self._is_setup:
@@ -494,43 +495,54 @@ class PianobarSkill(MycroftSkill):
             wait_while_speaking()
             self.handle_resume_song()
 
-    @intent_handler(IntentBuilder("").require("Love").require("Song"))
+    @intent_handler(IntentBuilder("PandoraLoveSongIntent").require("Love").require("Song"))
     def handle_love(self, message=None):
         if self.process:
+            utterance = message.data["utterance"]
+            if utterance.contains("don't") or utterance.contains("not"):
+                self.handle_ban(message)
+                return
             self.cmd("+")
             self.speak_dialog("love.song")
             # if self.piano_bar_state != "playing":
             #     self.handle_resume_song()
 
-    @intent_handler(IntentBuilder("").require("Ban").require("Song"))
+    @intent_handler(IntentBuilder("PandoraBanSongIntent").require("Ban").require("Song"))
     def handle_ban(self, message=None):
         if self.process:
             self.cmd("-")
             self.speak_dialog("ban.song")
 
-    @intent_handler(IntentBuilder("").require("Tired").require("Song"))
+    @intent_handler(IntentBuilder("PandoraTiredSongIntent").require("Tired").require("Song"))
     def handle_tired(self, message=None):
         if self.process:
             self.cmd("t")
             self.speak_dialog("tired.song")
 
-    @intent_handler(IntentBuilder("").require("Raise").require("Pandora").require("Volume"))
+    @intent_handler(IntentBuilder("PandoraVolumeRaiseIntent").require("Raise").require("Pandora").require("Volume"))
     def handle_volume_raise(self, message=None):
         if self.process:
             self.cmd(")")
             self.speak_dialog("raised.pandora.volume")
 
-    @intent_handler(IntentBuilder("").require("Lower").require("Pandora").require("Volume"))
+    @intent_handler(IntentBuilder("PandoraVolumeLowerIntent").require("Lower").require("Pandora").require("Volume"))
     def handle_volume_lower(self, message=None):
         if self.process:
             self.cmd("(")
             self.speak_dialog("lowered.pandora.volume")
 
-    @intent_handler(IntentBuilder("").require("Reset").require("Pandora").require("Volume"))
+    @intent_handler(IntentBuilder("PandoraVolumeResetIntent").require("Reset").require("Pandora").require("Volume"))
     def handle_volume_reset(self, message=None):
         if self.process:
             self.cmd("^")
             self.speak_dialog("reset.pandora.volume")
+
+    def handle_track_info(self):
+        if self.process:
+            song = self.settings["song_title"]
+            artist = self.settings["song_artist"]
+            album = self.settings["song_album"]
+            self.speak_dialog("track.info", {"song": song, "artist": artist, "album": album})
 
     def stop(self):
         LOG.info('STOPPING PANDORA')

--- a/__init__.py
+++ b/__init__.py
@@ -91,8 +91,8 @@ class PianobarSkill(MycroftSkill):
             self.cancel_scheduled_event('IdleCheck')
             return
         active = DisplayManager.get_active()
-        LOG.info("active: " + str(active))
-        if not active:
+        # LOG.info("active: " + str(active))
+        if not active or active == "PianobarSkill":
             # No activity, start to fall asleep
             self.idle_count += 1
 

--- a/__init__.py
+++ b/__init__.py
@@ -124,7 +124,6 @@ class PianobarSkill(MycroftSkill):
         self.add_event('mycroft.audio.service.pause', self.handle_pause)
         self.add_event('mycroft.audio.service.resume', self.handle_resume_song)
         self.add_event('mycroft.audio.service.next', self.handle_next_song)
-        self.add_event('mycroft.audio.service.track_info', self.handle_track_info)
 
     def on_websettings_changed(self):
         if not self._is_setup:
@@ -537,7 +536,8 @@ class PianobarSkill(MycroftSkill):
             self.cmd("^")
             self.speak_dialog("reset.pandora.volume")
 
-    def handle_track_info(self):
+    @intent_handler(IntentBuilder("PandoraTrackInfo").require("Song").require("Playing"))
+    def handle_track_info(self, message=None):
         if self.process:
             song = self.settings["song_title"]
             artist = self.settings["song_artist"]

--- a/__init__.py
+++ b/__init__.py
@@ -80,6 +80,8 @@ class PianobarSkill(MycroftSkill):
             self.handle_pause()
             self.piano_bar_state = "autopause"
 
+    def handle_listener_ended(self, message):
+        if self.piano_bar_state == "autopause":
             # Start idle check
             self.idle_count = 0
             self.cancel_scheduled_event('IdleCheck')
@@ -92,7 +94,7 @@ class PianobarSkill(MycroftSkill):
             return
         active = DisplayManager.get_active()
         # LOG.info("active: " + str(active))
-        if not active or active == "PianobarSkill":
+        if active == "PianobarSkill":  # or not active <- add in if resume no matter what
             # No activity, start to fall asleep
             self.idle_count += 1
 
@@ -202,6 +204,8 @@ class PianobarSkill(MycroftSkill):
                                       name='MonitorPianobar')
         self.add_event('recognizer_loop:record_begin',
                        self.handle_listener_started)
+        self.add_event('recognizer_loop:record_end',
+                       self.handle_listener_ended)
 
     def stop_monitor(self):
         # Clear any existing event

--- a/__init__.py
+++ b/__init__.py
@@ -499,12 +499,38 @@ class PianobarSkill(MycroftSkill):
         if self.process:
             self.cmd("+")
             self.speak_dialog("love.song")
+            # if self.piano_bar_state != "playing":
+            #     self.handle_resume_song()
 
     @intent_handler(IntentBuilder("").require("Ban").require("Song"))
     def handle_ban(self, message=None):
         if self.process:
             self.cmd("-")
             self.speak_dialog("ban.song")
+
+    @intent_handler(IntentBuilder("").require("Tired").require("Song"))
+    def handle_tired(self, message=None):
+        if self.process:
+            self.cmd("t")
+            self.speak_dialog("tired.song")
+
+    @intent_handler(IntentBuilder("").require("Raise").require("Pandora").require("Volume"))
+    def handle_volume_raise(self, message=None):
+        if self.process:
+            self.cmd(")")
+            self.speak_dialog("raised.pandora.volume")
+
+    @intent_handler(IntentBuilder("").require("Lower").require("Pandora").require("Volume"))
+    def handle_volume_lower(self, message=None):
+        if self.process:
+            self.cmd("(")
+            self.speak_dialog("lowered.pandora.volume")
+
+    @intent_handler(IntentBuilder("").require("Reset").require("Pandora").require("Volume"))
+    def handle_volume_reset(self, message=None):
+        if self.process:
+            self.cmd("^")
+            self.speak_dialog("reset.pandora.volume")
 
     def stop(self):
         LOG.info('STOPPING PANDORA')

--- a/__init__.py
+++ b/__init__.py
@@ -94,7 +94,7 @@ class PianobarSkill(MycroftSkill):
             return
         active = DisplayManager.get_active()
         # LOG.info("active: " + str(active))
-        if active == "PianobarSkill":  # or not active <- add in if resume no matter what
+        if active == "PianobarSkill" or not active:
             # No activity, start to fall asleep
             self.idle_count += 1
 
@@ -204,7 +204,7 @@ class PianobarSkill(MycroftSkill):
                                       name='MonitorPianobar')
         self.add_event('recognizer_loop:record_begin',
                        self.handle_listener_started)
-        self.add_event('recognizer_loop:record_end',
+        self.add_event('recognizer_loop:utterance',
                        self.handle_listener_ended)
 
     def stop_monitor(self):

--- a/__init__.py
+++ b/__init__.py
@@ -90,8 +90,9 @@ class PianobarSkill(MycroftSkill):
         if not self.piano_bar_state == "autopause":
             self.cancel_scheduled_event('IdleCheck')
             return
-
-        if DisplayManager.get_active() == '':
+        active = DisplayManager.get_active()
+        LOG.info("active: " + str(active))
+        if not active:
             # No activity, start to fall asleep
             self.idle_count += 1
 

--- a/__init__.py
+++ b/__init__.py
@@ -503,7 +503,7 @@ class PianobarSkill(MycroftSkill):
     def handle_love(self, message=None):
         if self.process:
             utterance = message.data["utterance"]
-            if utterance.contains("don't") or utterance.contains("not"):
+            if "don't" in utterance or "not" in utterance:
                 self.handle_ban(message)
                 return
             self.cmd("+")

--- a/__init__.py
+++ b/__init__.py
@@ -494,6 +494,18 @@ class PianobarSkill(MycroftSkill):
             wait_while_speaking()
             self.handle_resume_song()
 
+    @intent_handler(IntentBuilder("").require("Love").require("Song"))
+    def handle_love(self, message=None):
+        if self.process:
+            self.cmd("+")
+            self.speak_dialog("love.song")
+
+    @intent_handler(IntentBuilder("").require("Ban").require("Song"))
+    def handle_ban(self, message=None):
+        if self.process:
+            self.cmd("-")
+            self.speak_dialog("ban.song")
+
     def stop(self):
         LOG.info('STOPPING PANDORA')
         if not self.piano_bar_state == "paused":

--- a/__init__.py
+++ b/__init__.py
@@ -428,7 +428,7 @@ class PianobarSkill(MycroftSkill):
             self.speak_dialog("please.register.pandora")
 
     def handle_next_song(self, message=None):
-        if self.process and self.piano_bar_state == "playing":
+        if self.process:
             self.enclosure.mouth_think()
             self.cmd("n")
             self.piano_bar_state = "playing"

--- a/dialog/en-us/ban.song.dialog
+++ b/dialog/en-us/ban.song.dialog
@@ -1,0 +1,1 @@
+Banning song

--- a/dialog/en-us/love.song.dialog
+++ b/dialog/en-us/love.song.dialog
@@ -1,0 +1,1 @@
+Loving song

--- a/dialog/en-us/lowered.pandora.volume.dialog
+++ b/dialog/en-us/lowered.pandora.volume.dialog
@@ -1,0 +1,1 @@
+Lowered pandora volume

--- a/dialog/en-us/raised.pandora.volume.dialog
+++ b/dialog/en-us/raised.pandora.volume.dialog
@@ -1,0 +1,1 @@
+Raised pandora volume

--- a/dialog/en-us/reset.pandora.volume.dialog
+++ b/dialog/en-us/reset.pandora.volume.dialog
@@ -1,0 +1,1 @@
+Reset pandora volume

--- a/dialog/en-us/tired.song.dialog
+++ b/dialog/en-us/tired.song.dialog
@@ -1,0 +1,1 @@
+Okay, we'll put that song on the shelf for a while

--- a/dialog/en-us/track.info.dialog
+++ b/dialog/en-us/track.info.dialog
@@ -1,0 +1,1 @@
+Currently playing {song} by {artist} from {album}

--- a/vocab/en-us/Ban.voc
+++ b/vocab/en-us/Ban.voc
@@ -1,0 +1,3 @@
+ban
+dislike
+hate

--- a/vocab/en-us/Love.voc
+++ b/vocab/en-us/Love.voc
@@ -1,0 +1,2 @@
+love
+like

--- a/vocab/en-us/Lower.voc
+++ b/vocab/en-us/Lower.voc
@@ -1,0 +1,4 @@
+lower
+down
+quiet
+quieter

--- a/vocab/en-us/Playing.voc
+++ b/vocab/en-us/Playing.voc
@@ -1,0 +1,4 @@
+playing
+this
+info
+information

--- a/vocab/en-us/Raise.voc
+++ b/vocab/en-us/Raise.voc
@@ -1,0 +1,4 @@
+raise
+up
+loud
+louder

--- a/vocab/en-us/Reset.voc
+++ b/vocab/en-us/Reset.voc
@@ -1,0 +1,2 @@
+reset
+revert

--- a/vocab/en-us/Reset.voc
+++ b/vocab/en-us/Reset.voc
@@ -1,2 +1,3 @@
 reset
 revert
+restore

--- a/vocab/en-us/Tired.voc
+++ b/vocab/en-us/Tired.voc
@@ -1,0 +1,5 @@
+tired
+bored
+boring
+bores
+shelf

--- a/vocab/en-us/Volume.voc
+++ b/vocab/en-us/Volume.voc
@@ -1,0 +1,3 @@
+volume
+sound
+loudness


### PR DESCRIPTION
This adds some pianobar features such as loving a song, banning a song, tired of a song and volume controls. This also takes advantage of the already implemented self.settings data and will give you information on the current song.

I also had two problems that weren't working on the version of mycroft I'm running (18.2.6 beta). One was with the next track mentioned here: https://github.com/ethanaward/pianobar-skill/issues/49 . And another was with the "auto ducking." I changed how auto ducking works a little bit while keeping the original code: 
It pauses when someone is about to speak and then it waits until you're done speaking to schedule an event that checks in 2 seconds to see what the "active" skill is. This just wasn't working at all because when I debugged it, the skill was never an empty string and would resume too quickly if it only used the record_begin event.